### PR TITLE
Fix: Manually load the aurelia-loader-webpack

### DIFF
--- a/tests/test1.spec.ts
+++ b/tests/test1.spec.ts
@@ -1,3 +1,4 @@
+import "aurelia-loader-webpack";
 import "aurelia-polyfills";
 import { bootstrap,  starting } from "aurelia-bootstrapper";
 import { Container, PLATFORM, Expression } from "aurelia-framework";
@@ -16,6 +17,10 @@ describe("aspiration", () => {
 
     it("proves that the tests run", () => {
         expect(true).toBeTruthy();
-    } )
+    })
+
+    it("fails the bad test too", () => {
+        expect(false).toBeTruthy();
+    })
 });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "target": "es6",
-        "module": "esnext",
+        "module": "commonjs",
         "moduleResolution": "node",
         "strict": true,
         "lib": [ "es2017", "dom" ],


### PR DESCRIPTION
This was a really strange issue and took a lot of time to diagnose. Fundamentally, the issue seems to be from using an entry point other than aurelia-bootstrapper, which seems to cause the aurelia-bootstrapper to execute before the aurelia-loader-webpack could execute, and so the bootstrapper couldn't find the appropriate loader.

The workaround was to manually import the aurelia-loader-webpack before the aurelia-bootstrapper.